### PR TITLE
Dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_install:
   # PRs made to 'master' branch should always orginate from another repo or the 'dev' branch
   - '[ $TRAVIS_PULL_REQUEST = "false" ] || [ $TRAVIS_BRANCH != "master" ] || ([ $TRAVIS_PULL_REQUEST_SLUG = $TRAVIS_REPO_SLUG ] && [ $TRAVIS_PULL_REQUEST_BRANCH = "dev" ])'
   # Pull the docker image first so the test doesn't wait for this
-  - docker pull nfcore/deepvariant:dev
+  - docker pull nfcore/deepvariant
   # Fake the tag locally so that the pipeline runs properly
-  - docker tag nfcore/deepvariant:dev nfcore/deepvariant:dev
+  - docker tag nfcore/deepvariant nfcore/deepvariant:latest
 
 install:
   # Install Nextflow

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_install:
   # PRs made to 'master' branch should always orginate from another repo or the 'dev' branch
   - '[ $TRAVIS_PULL_REQUEST = "false" ] || [ $TRAVIS_BRANCH != "master" ] || ([ $TRAVIS_PULL_REQUEST_SLUG = $TRAVIS_REPO_SLUG ] && [ $TRAVIS_PULL_REQUEST_BRANCH = "dev" ])'
   # Pull the docker image first so the test doesn't wait for this
-  - docker pull nfcore/deepvariant:dev
+  - docker pull nfcore/deepvariant
   # Fake the tag locally so that the pipeline runs properly
-  - docker tag nfcore/deepvariant:dev nfcore/deepvariant:dev
+  - docker tag nfcore/deepvariant nfcore/deepvariant:latest
 
 install:
   # Install Nextflow
@@ -26,7 +26,7 @@ install:
   - mkdir ${TRAVIS_BUILD_DIR}/tests && cd ${TRAVIS_BUILD_DIR}/tests
 
 env:
-  - NXF_VER='18.11.0-edge' # Specify a minimum NF version that should be tested and work
+  - NXF_VER='18.10.1' # Specify a minimum NF version that should be tested and work
   - NXF_VER='' # Plus: get the latest NF version and check that it works
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - mkdir ${TRAVIS_BUILD_DIR}/tests && cd ${TRAVIS_BUILD_DIR}/tests
 
 env:
-  - NXF_VER='18.11.0' # Specify a minimum NF version that should be tested and work
+  - NXF_VER='18.11.0-edge' # Specify a minimum NF version that should be tested and work
   - NXF_VER='' # Plus: get the latest NF version and check that it works
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_install:
   # PRs made to 'master' branch should always orginate from another repo or the 'dev' branch
   - '[ $TRAVIS_PULL_REQUEST = "false" ] || [ $TRAVIS_BRANCH != "master" ] || ([ $TRAVIS_PULL_REQUEST_SLUG = $TRAVIS_REPO_SLUG ] && [ $TRAVIS_PULL_REQUEST_BRANCH = "dev" ])'
   # Pull the docker image first so the test doesn't wait for this
-  - docker pull nfcore/deepvariant
+  - docker pull nfcore/deepvariant:dev
   # Fake the tag locally so that the pipeline runs properly
-  - docker tag nfcore/deepvariant nfcore/deepvariant:latest
+  - docker tag nfcore/deepvariant:dev nfcore/deepvariant:dev
 
 install:
   # Install Nextflow

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - mkdir ${TRAVIS_BUILD_DIR}/tests && cd ${TRAVIS_BUILD_DIR}/tests
 
 env:
-  - NXF_VER='0.32.0' # Specify a minimum NF version that should be tested and work
+  - NXF_VER='18.11.0' # Specify a minimum NF version that should be tested and work
   - NXF_VER='' # Plus: get the latest NF version and check that it works
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ In summary, the main changes are:
 - Rebranding and renaming throughout the pipeline to nf-core
 - Updating many parts of the pipeline config and style to meet nf-core standards
 - Continuous integration tests with Travis CI
+- Dependencies installed via conda
+- Added support for BAM input as file, not just a folder
+- Added channels to process input files
+- Added separate processes for each of the steps in FASTA file preprocessing
+- Use of genomes config to specify relevant reference genome files similar to igenomes
+- Added BAM size dependent setting of memory
 - Slightly improved documentation
 
 ...and many more minor tweaks.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # nf-core/deepvariant
 
-**UNDER DEVELOPMENT: Deep Variant as a Nextflow pipeline**
+**Deep Variant as a Nextflow pipeline**
 
 [![Build Status](https://travis-ci.org/nf-core/deepvariant.svg?branch=master)](https://travis-ci.org/nf-core/deepvariant)
 [![Nextflow](https://img.shields.io/badge/nextflow-%E2%89%A518.10.1-brightgreen.svg)](https://www.nextflow.io/)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **UNDER DEVELOPMENT: Deep Variant as a Nextflow pipeline**
 
 [![Build Status](https://travis-ci.org/nf-core/deepvariant.svg?branch=master)](https://travis-ci.org/nf-core/deepvariant)
-[![Nextflow](https://img.shields.io/badge/nextflow-%E2%89%A50.32.0-brightgreen.svg)](https://www.nextflow.io/)
+[![Nextflow](https://img.shields.io/badge/nextflow-%E2%89%A518.10.1-brightgreen.svg)](https://www.nextflow.io/)
 [![Gitter](https://img.shields.io/badge/gitter-%20join%20chat%20%E2%86%92-4fb99a.svg)](https://gitter.im/nf-core/Lobby)
 
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](http://bioconda.github.io/)

--- a/conf/base.config
+++ b/conf/base.config
@@ -23,7 +23,7 @@ process {
 
   withName:preprocess_bam {
   cpus = { check_max( 20, 'cpus' ) }
-  memory = { check_max( bam.size() * 5.GB  * task.attempt, 'memory'}
+  memory = { check_max( bam.size() * 5.GB  * task.attempt, 'memory')}
   time = { check_max( 10.h * task.attempt, 'time' ) }
   }
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -23,17 +23,17 @@ process {
 
   withName:make_examples {
   cpus = { check_max( 20, 'cpus' ) }
-  memory = { bam.size() < 1000000000 ? 4.GB : check_max( (bam.size() >> 30) * 10.GB * task.attempt, 'memory')}
+  memory = { bam.size() < 1000000000 ? 4.GB : check_max( bam.size() >> 30 * 10.GB * task.attempt, 'memory')}
   time = { check_max( 10.h * task.attempt, 'time' ) }
   }
   withName:call_variants {
   cpus = { check_max( 20, 'cpus' ) }
-  memory = { bam.size() < 1000000000 ? 4.GB : check_max( ( bam.size()/1024/1024/1024) * 10.GB * task.attempt, 'memory')}
+  memory = { bam.size() < 1000000000 ? 4.GB : check_max( bam.size() >> 30 * 10.GB * task.attempt, 'memory')}
   time = { check_max( 10.h * task.attempt, 'time' ) }
   }
   withName:postprocess_variants {
   cpus = { check_max( 20, 'cpus' ) }
-  memory = { bam.size() < 1000000000 ? 4.GB : check_max( ( bam.size()/1024/1024/1024) * 10.GB * task.attempt, 'memory')}
+  memory = { bam.size() < 1000000000 ? 4.GB : check_max( bam.size() >> 30 * 10.GB * task.attempt, 'memory')}
   time = { check_max( 10.h * task.attempt, 'time' ) }
   }
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -21,6 +21,13 @@ process {
   maxRetries = 1
   maxErrors = '-1'
 
+  withName:preprocess_bam {
+  cpus = { check_max( 20, 'cpus' ) }
+  memory = { check_max( bam.size() * 5.GB  * task.attempt, 'memory'}
+  time = { check_max( 10.h * task.attempt, 'time' ) }
+  }
+
+
 }
 
 params {

--- a/conf/base.config
+++ b/conf/base.config
@@ -23,7 +23,7 @@ process {
 
   withName:make_examples {
   cpus = { check_max( 20, 'cpus' ) }
-  memory = { check_max( bam.size() * 5.GB  * task.attempt, 'memory')}
+  memory = { check_max( bam.size().toGiga() * 5.GB  * task.attempt, 'memory')}
   time = { check_max( 10.h * task.attempt, 'time' ) }
   }
   withName:call_variants {

--- a/conf/base.config
+++ b/conf/base.config
@@ -23,17 +23,17 @@ process {
 
   withName:make_examples {
   cpus = { check_max( 20, 'cpus' ) }
-  memory = { bam.size() < 1000000000 ? 4.GB : check_max( bam.size() >> 30 * 10.GB * task.attempt, 'memory')}
+  memory = { bam.size() < 1000000000 ? 4.GB : check_max( (bam.size() >> 30) * 10.GB * task.attempt, 'memory')}
   time = { check_max( 10.h * task.attempt, 'time' ) }
   }
   withName:call_variants {
   cpus = { check_max( 20, 'cpus' ) }
-  memory = { bam.size() < 1000000000 ? 4.GB : check_max( bam.size() >> 30 * 10.GB * task.attempt, 'memory')}
+  memory = { bam.size() < 1000000000 ? 4.GB : check_max( (bam.size() >> 30) * 10.GB * task.attempt, 'memory')}
   time = { check_max( 10.h * task.attempt, 'time' ) }
   }
   withName:postprocess_variants {
   cpus = { check_max( 20, 'cpus' ) }
-  memory = { bam.size() < 1000000000 ? 4.GB : check_max( bam.size() >> 30 * 10.GB * task.attempt, 'memory')}
+  memory = { bam.size() < 1000000000 ? 4.GB : check_max( (bam.size() >> 30) * 10.GB * task.attempt, 'memory')}
   time = { check_max( 10.h * task.attempt, 'time' ) }
   }
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -21,7 +21,17 @@ process {
   maxRetries = 1
   maxErrors = '-1'
 
-  withName:preprocess_bam {
+  withName:make_examples {
+  cpus = { check_max( 20, 'cpus' ) }
+  memory = { check_max( bam.size() * 5.GB  * task.attempt, 'memory')}
+  time = { check_max( 10.h * task.attempt, 'time' ) }
+  }
+  withName:call_variants {
+  cpus = { check_max( 20, 'cpus' ) }
+  memory = { check_max( bam.size() * 5.GB  * task.attempt, 'memory')}
+  time = { check_max( 10.h * task.attempt, 'time' ) }
+  }
+  withName:postprocess_variants {
   cpus = { check_max( 20, 'cpus' ) }
   memory = { check_max( bam.size() * 5.GB  * task.attempt, 'memory')}
   time = { check_max( 10.h * task.attempt, 'time' ) }

--- a/conf/base.config
+++ b/conf/base.config
@@ -23,17 +23,17 @@ process {
 
   withName:make_examples {
   cpus = { check_max( 20, 'cpus' ) }
-  memory = { check_max( bam.size() * 5.GB  * task.attempt, 'memory')}
+  memory = { bam.size() < 1000000000 ? 4.GB : check_max( ( bam.size()/1024/1024/1024) * 10.GB * task.attempt, 'memory')}
   time = { check_max( 10.h * task.attempt, 'time' ) }
   }
   withName:call_variants {
   cpus = { check_max( 20, 'cpus' ) }
-  memory = { check_max( bam.size() * 5.GB  * task.attempt, 'memory')}
+  memory = { bam.size() < 1000000000 ? 4.GB : check_max( ( bam.size()/1024/1024/1024) * 10.GB * task.attempt, 'memory')}
   time = { check_max( 10.h * task.attempt, 'time' ) }
   }
   withName:postprocess_variants {
   cpus = { check_max( 20, 'cpus' ) }
-  memory = { check_max( bam.size() * 5.GB  * task.attempt, 'memory')}
+  memory = { bam.size() < 1000000000 ? 4.GB : check_max( ( bam.size()/1024/1024/1024) * 10.GB * task.attempt, 'memory')}
   time = { check_max( 10.h * task.attempt, 'time' ) }
   }
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -23,7 +23,7 @@ process {
 
   withName:make_examples {
   cpus = { check_max( 20, 'cpus' ) }
-  memory = { check_max( bam.size().toGiga() * 5.GB  * task.attempt, 'memory')}
+  memory = { check_max( ( bam.size()/1024/1024/1024)  * 5.GB  * task.attempt, 'memory')}
   time = { check_max( 10.h * task.attempt, 'time' ) }
   }
   withName:call_variants {

--- a/conf/binac.config
+++ b/conf/binac.config
@@ -1,0 +1,23 @@
+vim: syntax=groovy
+-*- mode: groovy;-*-
+ * ----------------------------------------------------------------------------
+ *  Nextflow config file for use with Singularity on BINAC cluster in Tuebingen
+ * ----------------------------------------------------------------------------
+ * Defines basic usage limits and singularity image id.
+ */
+
+singularity {
+    enabled = true
+}
+
+process {
+    beforeScript = 'module load devel/singularity/2.6.0'
+    executor = 'pbs'
+    queue = 'short'
+}
+
+params {
+  max_memory = 128.GB
+  max_cpus = 28
+  max_time = 48.h
+}

--- a/conf/binac.config
+++ b/conf/binac.config
@@ -1,5 +1,4 @@
-vim: syntax=groovy
--*- mode: groovy;-*-
+/*
  * ----------------------------------------------------------------------------
  *  Nextflow config file for use with Singularity on BINAC cluster in Tuebingen
  * ----------------------------------------------------------------------------

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -51,6 +51,7 @@
   - [`--plaintext_emails`](#--plaintext_emails)
   - [`--sampleLevel`](#--sampleLevel)
   - [`--multiqc_config`](#--multiqc_config)
+- [Memory](#memory)
 
 ## General Nextflow info
 
@@ -323,3 +324,6 @@ Set to receive plain-text e-mails instead of HTML formatted.
 
 ### `--multiqc_config`
 Specify a path to a custom MultiQC configuration file.
+
+## Memory
+DeepVariant is quite memory intensive. The most memory intensive process is `make_examples`. The memory requirement should be approximately 10-15x the size of your BAM file. For example, for a 5GB BAM file the memory should be set to 50GB. Fortunately this is set automaticaally for you in `base.config` for all of the man deepvariant processes, so you don't need change aything more and can run the pipeline as normal.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -326,4 +326,4 @@ Set to receive plain-text e-mails instead of HTML formatted.
 Specify a path to a custom MultiQC configuration file.
 
 ## Memory
-DeepVariant is quite memory intensive. The most memory intensive process is `make_examples`. The memory requirement should be approximately 10-15x the size of your BAM file. For example, for a 5GB BAM file the memory should be set to 50GB. Fortunately this is set automaticaally for you in `base.config` for all of the man deepvariant processes, so you don't need change aything more and can run the pipeline as normal.
+DeepVariant is quite memory intensive. The most memory intensive process is `make_examples`. The memory requirement should be approximately 10-15x the size of your BAM file. For example, for a 5GB BAM file the memory should be set to 50GB. Fortunately this is set automaticaally for you in `base.config` for all of the man deepvariant processes, so you don't need change anything more and can run the pipeline as normal.

--- a/main.nf
+++ b/main.nf
@@ -334,7 +334,7 @@ process preprocess_bam{
 ********************************************************************/
 
 process make_examples{
-  memory = bam.size().toGiga() * 5
+  memory = "${bam}".size().toGiga() * 5
   tag "${bam}"
   publishDir "${params.outdir}/make_examples", mode: 'copy',
   saveAs: {filename -> "logs/log"}

--- a/main.nf
+++ b/main.nf
@@ -334,6 +334,7 @@ process preprocess_bam{
 ********************************************************************/
 
 process make_examples{
+  
   tag "${bam}"
   publishDir "${params.outdir}/make_examples", mode: 'copy',
   saveAs: {filename -> "logs/log"}

--- a/main.nf
+++ b/main.nf
@@ -334,7 +334,6 @@ process preprocess_bam{
 ********************************************************************/
 
 process make_examples{
-  memory = "${bam}".size().toGiga() * 5
   tag "${bam}"
   publishDir "${params.outdir}/make_examples", mode: 'copy',
   saveAs: {filename -> "logs/log"}

--- a/main.nf
+++ b/main.nf
@@ -334,7 +334,7 @@ process preprocess_bam{
 ********************************************************************/
 
 process make_examples{
-
+  memory = bam.size().toGiga() * 5
   tag "${bam}"
   publishDir "${params.outdir}/make_examples", mode: 'copy',
   saveAs: {filename -> "logs/log"}

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,7 +11,7 @@
  // Global default params, used in configs
  params {
 
-   container = 'nfcore/deepvariant:dev'
+   container = 'nfcore/deepvariant:latest'
 
    help = false
    outdir = 'results'
@@ -119,7 +119,7 @@ manifest {
   homePage = 'https://github.com/nf-core/deepvariant'
   description = 'UNDER DEVELOPMENT: Deep Variant as a Nextflow pipeline'
   mainScript = 'main.nf'
-  nextflowVersion = '=18.11.0-edge'
+  nextflowVersion = '>=18.10.1'
   version = '1.0dev'
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -119,7 +119,7 @@ manifest {
   homePage = 'https://github.com/nf-core/deepvariant'
   description = 'UNDER DEVELOPMENT: Deep Variant as a Nextflow pipeline'
   mainScript = 'main.nf'
-  nextflowVersion = '>=18.11.0-edge'
+  nextflowVersion = '=18.11.0-edge'
   version = '1.0dev'
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -119,7 +119,7 @@ manifest {
   homePage = 'https://github.com/nf-core/deepvariant'
   description = 'UNDER DEVELOPMENT: Deep Variant as a Nextflow pipeline'
   mainScript = 'main.nf'
-  nextflowVersion = '>=0.32.0'
+  nextflowVersion = '>=18.11.0'
   version = '1.0dev'
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,12 +62,12 @@ profiles {
   binac {
     includeConfig 'conf/base.config'
     includeConfig 'conf/binac.config'
-    includeConfig 'conf/igenomes.config'
+    includeConfig 'conf/genomes.config'
   }
   awsbatch {
     includeConfig 'conf/base.config'
     includeConfig 'conf/awsbatch.config'
-    includeConfig 'conf/igenomes.config'
+    includeConfig 'conf/genomes.config'
   }
   test {
     includeConfig 'conf/base.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -119,7 +119,7 @@ manifest {
   homePage = 'https://github.com/nf-core/deepvariant'
   description = 'UNDER DEVELOPMENT: Deep Variant as a Nextflow pipeline'
   mainScript = 'main.nf'
-  nextflowVersion = '>=18.11.0'
+  nextflowVersion = '>=18.11.0-edge'
   version = '1.0dev'
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,7 +11,7 @@
  // Global default params, used in configs
  params {
 
-   container = 'nfcore/deepvariant:latest'
+   container = 'nfcore/deepvariant:dev'
 
    help = false
    outdir = 'results'

--- a/nextflow.config
+++ b/nextflow.config
@@ -58,6 +58,12 @@ profiles {
   singularity {
     singularity.enabled = true
   }
+
+  binac {
+    includeConfig 'conf/base.config'
+    includeConfig 'conf/binac.config'
+    includeConfig 'conf/igenomes.config'
+  }
   awsbatch {
     includeConfig 'conf/base.config'
     includeConfig 'conf/awsbatch.config'


### PR DESCRIPTION
Made changes for deepvariant release 1.0
Including adding BAM file size dependent setting of memory for the main deepvariant processes to prevent users needing to set memory to 10x BAM file size manually

## PR checklist
 - [X] This comment contains a description of changes (with reason)
 - [X] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [X] Make sure your code lints (`nf-core lint .`).
 - [X] Documentation in `docs` is updated
 - [X] `CHANGELOG.md` is updated
 - [X] `README.md` is updated
